### PR TITLE
Potential fix for code scanning alert no. 20: Information exposure through an exception

### DIFF
--- a/app.py
+++ b/app.py
@@ -157,9 +157,11 @@ def xlists():
         greylist = load_greylist()
         return render_template("xlists.html", greylist=greylist)
     except IOError as e:
-        return jsonify({"error": f"An error occurred while reading the file: {e}"}), 500
+        app.logger.error(f"An IOError occurred while reading the file: {e}")
+        return jsonify({"error": "An internal error has occurred while reading the file."}), 500
     except (KeyError, ValueError) as e:
-        return jsonify({"error": f"An error occurred while processing the data: {e}"}), 500
+        app.logger.error(f"An error occurred while processing the data: {e}")
+        return jsonify({"error": "An internal error has occurred while processing the data."}), 500
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Potential fix for [https://github.com/OwOBots/quickplay-server-finder/security/code-scanning/20](https://github.com/OwOBots/quickplay-server-finder/security/code-scanning/20)

To fix the problem, we should avoid exposing the exception details directly to the user. Instead, we can log the detailed error message on the server and return a generic error message to the user. This approach ensures that developers still have access to the detailed error information for debugging purposes, while users receive a generic message that does not reveal sensitive information.

1. Modify the exception handling code to log the detailed error message.
2. Return a generic error message to the user.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
